### PR TITLE
fix: Wrong static webfiles location in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can run a development version of aw-webui with your main version of Activity
 The assets are stored in the following directories (relative to your installation directory), depending on if you use aw-server-python (default) or aw-server-rust:
 
  - aw-server-python: `activitywatch/aw-server/aw_server/static/`
- - aw-server-rust: `activitywatch/aw-server-rust/static/`
+ - aw-server-rust: `activitywatch/aw-server-rust/aw-webui/dist/`
 
 Either copy the assets manually, or run `make build` from the `aw-server` parent directory to rebuild and copy the assets for you.
 


### PR DESCRIPTION
There is no `static` folder in case of aw-server-rust (unlike aw-server-python), even while packaging rust server, files are directly taken from `aw-server-rust/aw-webui/dist/`.

https://github.com/ActivityWatch/aw-server-rust/blob/7c2b31f173194d75634079128a27ed06d83365b1/Makefile#L86