### PR TITLE
fix: NewReleaseNotification cannot be hidden/disabled

### DIFF
--- a/src/components/NewReleaseNotification.vue
+++ b/src/components/NewReleaseNotification.vue
@@ -40,7 +40,7 @@ export default {
     };
   },
   computed: {
-    ...mapWritableState(useSettingsStore, { data: 'newReleaseNotification' }),
+    ...mapWritableState(useSettingsStore, { data: 'newReleaseCheckData' }),
   },
   async mounted() {
     await useSettingsStore().ensureLoaded();


### PR DESCRIPTION
- Typo is settingStore data name
- component NewReleaseNotification cannot be permanently disabled or hidden since state data is not in sync with settingStore's state