### PR TITLE
feat: Never treat apps or titles as afk

### DIFF
--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -58,6 +58,7 @@ export interface QueryOptions {
   filter_categories?: string[][];
   dont_query_inactive?: boolean;
   force?: boolean;
+  neverTreatAsAfkFilter?: string;
 }
 
 interface State {
@@ -301,7 +302,7 @@ export const useActivityStore = defineStore('activity', {
     },
 
     async query_multidevice_full(
-      { timeperiod, filter_categories, filter_afk }: QueryOptions,
+      { timeperiod, filter_categories, filter_afk, neverTreatAsAfkFilter }: QueryOptions,
       hosts: string[]
     ) {
       const periods = [timeperiodToStr(timeperiod)];
@@ -313,6 +314,7 @@ export const useActivityStore = defineStore('activity', {
         categories,
         filter_categories,
         host_params: {},
+        neverTreatAsAfkFilter
       });
       const data = await getClient().query(periods, q);
       const data_window = data[0].window;
@@ -329,6 +331,7 @@ export const useActivityStore = defineStore('activity', {
       filter_afk,
       include_audible,
       include_stopwatch,
+      neverTreatAsAfkFilter,
     }: QueryOptions) {
       const periods = [timeperiodToStr(timeperiod)];
       const categories = useCategoryStore().classes_for_query;
@@ -345,6 +348,7 @@ export const useActivityStore = defineStore('activity', {
         categories,
         filter_categories,
         include_audible,
+        neverTreatAsAfkFilter,
       });
       const data = await getClient().query(periods, q);
       const data_window = data[0].window;
@@ -382,6 +386,7 @@ export const useActivityStore = defineStore('activity', {
       filter_afk,
       include_stopwatch,
       dontQueryInactive,
+      neverTreatAsAfkFilter,
     }: QueryOptions & { dontQueryInactive: boolean }) {
       // TODO: Needs to be adapted for Android
       let periods: string[];
@@ -454,6 +459,7 @@ export const useActivityStore = defineStore('activity', {
             categories,
             filter_categories,
             filter_afk,
+            neverTreatAsAfkFilter
           })
         );
         data = data.concat(result);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -18,6 +18,7 @@ interface State {
 
   newReleaseCheckData: Record<string, any>;
   userSatisfactionPollData: Record<string, any>;
+  ActivityData: Record<string, any>;
 
   // Whether to show certain WIP features
   devmode: boolean;
@@ -48,6 +49,10 @@ export const useSettingsStore = defineStore('settings', {
       timesChecked: 0,
     },
     userSatisfactionPollData: {},
+
+    ActivityData: {
+      neverTreatAsAfkFilter: '',
+    },
 
     // Developer settings
     // NOTE: PRODUCTION might be undefined (in tests, for example)

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -203,6 +203,7 @@ export default {
   computed: {
     ...mapState(useViewsStore, ['views']),
     ...mapState(useSettingsStore, ['devmode']),
+    ...mapState(useSettingsStore, ['ActivityData']),
 
     // number of filters currently set (different from defaults)
     filters_set() {
@@ -406,6 +407,7 @@ export default {
         include_audible: this.include_audible,
         include_stopwatch: this.include_stopwatch,
         filter_categories: this.filter_categories,
+        neverTreatAsAfkFilter: this.ActivityData.neverTreatAsAfkFilter,
       };
       await this.activityStore.ensure_loaded(queryOptions);
     },

--- a/src/views/settings/NeverAfkFilterSettings.vue
+++ b/src/views/settings/NeverAfkFilterSettings.vue
@@ -1,0 +1,35 @@
+<template lang="pug">
+div
+  div.d-sm-flex.justify-content-between
+    div
+      h5.mb-2.mb-sm-0 Never Treat as Afk Filter
+    div
+      b-form-input(size="sm" v-model="NeverAfkFilterSettings")
+          
+  small
+    | Apps or Titles passing this Regex filter will never be counted as afk.
+</template>
+
+<script>
+import { useSettingsStore } from '~/stores/settings';
+
+export default {
+  name: 'NeverAfkFilterSettings',
+  data() {
+    return {
+      settingsStore: useSettingsStore(),
+    };
+  },
+  computed: {
+    NeverAfkFilterSettings: {
+      get() {
+        return this.settingsStore.ActivityData.neverTreatAsAfkFilter;
+      },
+      set(value) {
+        console.log('Setting NeverAfkFilterSetting to ' + value);
+        this.settingsStore.update({ ActivityData : { neverTreatAsAfkFilter: value }});
+      },
+    },
+  },
+};
+</script>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -29,6 +29,10 @@ div
   ColorSettings
 
   hr
+  
+  NeverAfkFilterSettings
+
+  hr
 
   CategorizationSettings
 
@@ -48,6 +52,7 @@ import LandingPageSettings from '~/views/settings/LandingPageSettings.vue';
 import DeveloperSettings from '~/views/settings/DeveloperSettings.vue';
 import Theme from '~/views/settings/Theme.vue';
 import ColorSettings from '~/views/settings/ColorSettings.vue';
+import NeverAfkFilterSettings from '~/views/settings/NeverAfkFilterSettings.vue';
 
 export default {
   name: 'Settings',
@@ -60,6 +65,7 @@ export default {
     Theme,
     ColorSettings,
     DeveloperSettings,
+    NeverAfkFilterSettings,
   },
   async created() {
     await this.init();


### PR DESCRIPTION
- Never treat some app with process names or titles matching a Regex pattern as AFK
- Added a browser setting for the same
- Future todo can be to implement a server query function of the form filter_keyvalues_regex( <events>, "*", <Regex> ) which will match all attr's of event like categorize() (future url support etc.)