### PR TITLE
fix: Display proper error content in e2e test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -124,11 +124,14 @@ jobs:
           npm run serve &
           sleep 3  # give a few seconds
     - name: Run e2e tests with testcafe
+      id: e2e
       uses: DevExpress/testcafe-action@latest
       with:
         # NOTE: --skip-js-errors should be removed when things work properly
         args: "--skip-js-errors chrome test/e2e/"
     - name: Move screenshots to subdir
+      # Run this step even if e2e tests flag failure
+      if: ${{ success() || steps.e2e.conclusion == 'failure'}}
       env:
         aw_server: ${{ matrix.aw-server }}
         aw_version: ${{ matrix.aw-version }}
@@ -136,6 +139,7 @@ jobs:
         mkdir -p screenshots/dist/$aw_server/$aw_version
         mv screenshots/*.png screenshots/dist/$aw_server/$aw_version
     - name: Upload screenshots
+      if: ${{ success() || steps.e2e.conclusion == 'failure'}}
       uses: actions/upload-artifact@v2-preview
       with:
         name: screenshots

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 	npm test
 
 test-e2e:
-	npx testcafe firefox test/e2e/ -s takeOnFails=true
+	npx testcafe chrome test/e2e/ -s takeOnFails=true
 
 typing-coverage:
 	npx typescript-coverage-report

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -85,11 +85,11 @@ fixture(`Activity view`).page(`${baseURL}/#/activity/fakedata`);
 test('Screenshot the activity view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'activity.png',
     fullPage: true,
   });
+  await checkNoError(t);
 
   // TODO: resize to mobile size and take another screenshot
 });
@@ -102,7 +102,6 @@ const durationOption = durationSelect.find('option');
 test('Screenshot the timeline view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
-  await checkNoError(t);
   await t
     .click(durationSelect)
     .click(durationOption.withText('12h'))
@@ -113,6 +112,7 @@ test('Screenshot the timeline view', async t => {
     path: 'timeline.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });
 
 fixture(`Buckets view`).page(`${baseURL}/#/buckets/`);
@@ -120,22 +120,22 @@ fixture(`Buckets view`).page(`${baseURL}/#/buckets/`);
 test('Screenshot the buckets view', async t => {
   await hide_devonly(t);
   await t.wait(1000);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'buckets.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });
 
 fixture(`Setting view`).page(`${baseURL}/#/settings/`);
 
 test('Screenshot the settings view', async t => {
   await hide_devonly(t);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'settings.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });
 
 fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`);
@@ -143,9 +143,9 @@ fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`);
 test('Screenshot the stopwatch view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'stopwatch.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -43,11 +43,11 @@ async function waitForLoading(t) {
 }
 
 async function checkNoError(t) {
-  const $error = Selector('div').withText(/[Ee]rror/g);
+  const $error = Selector('div.alert').withText(/[Ee]rror/g);
   try {
     await t.expect(await $error.count).eql(0);
   } catch (e) {
-    console.log('Errors found: ' + $error);
+    console.log('Errors found: ' + (await $error.textContent));
     throw e;
   }
 }


### PR DESCRIPTION
- use chrome as being done in CI
- Narrow down Selector to div with alert class else larger vue app dialog will be matched